### PR TITLE
Revert "Update manufacturer_specific.xml"

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -71,7 +71,6 @@
 		<Product type="0004" id="0050" name="DSD31 Siren Gen5" config="aeon_labs/dsd31.xml"/>
         <!-- US-market products start with type prefix "01" -->
 		<Product type="0102" id="0059" name="Recessed Door Sensor Gen5" config="aeon_labs/recessed_doorsensor_gen5.xml"/>
-        	<Product type="0101" id="005a" name="Z-Stick Gen5"/>
         <!-- AU-market products start with type prefix "02" -->
 		<Product type="0202" id="0059" name="Recessed Door Sensor Gen5" config="aeon_labs/recessed_doorsensor_gen5.xml"/>
 		
@@ -300,7 +299,6 @@
 	</Manufacturer>
 	<Manufacturer id="0020" name="General Electric">
 		<Product type="8007" id="1390" name="Wireless Lighting Control"/>
-		<Product type="4952" id="3032" name="Wireless Lighting Control"/>
 	</Manufacturer>
 	<Manufacturer id="0099" name="GreenWave">
 		<Product type="0001" id="0002" name="One Gateway"/>


### PR DESCRIPTION
Reverts SpudGunMan/open-zwave#1

the GE code can be moved to the GE section and not th General Electric section


this would be better code
<Product type="4952" id="3032" name="45609 On/Off Relay Switch" config="ge/relay.xml"/>
